### PR TITLE
include interfaceProperties

### DIFF
--- a/Allwclean
+++ b/Allwclean
@@ -3,6 +3,7 @@ cd "${0%/*}" || exit    # Run from this directory
 #------------------------------------------------------------------------------
 
 wclean libso laserDTRM
+wclean libso interfaceProperties
 wclean libso phasesSystem
 ./WENOEXT/Allwclean
 wclean

--- a/Allwmake
+++ b/Allwmake
@@ -7,9 +7,9 @@ echo "Building external libraries"
 ./WENOEXT/Allwmake
 
 echo "Building application"
+wmake $targetType interfaceProperties
 wmake $targetType laserDTRM
 wmake $targetType phasesSystem
-wmake $targetType interfaceProperties
 wmake $targetType
 
 

--- a/Allwmake
+++ b/Allwmake
@@ -9,6 +9,7 @@ echo "Building external libraries"
 echo "Building application"
 wmake $targetType laserDTRM
 wmake $targetType phasesSystem
+wmake $targetType interfaceProperties
 wmake $targetType
 
 

--- a/Make/options
+++ b/Make/options
@@ -11,7 +11,7 @@ EXE_INC = \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
-    -I$(LIB_SRC)/transportModels/interfaceProperties/lnInclude \
+    -I./transportModels/interfaceProperties/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/radiation/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/specie/lnInclude \

--- a/Make/options
+++ b/Make/options
@@ -11,7 +11,7 @@ EXE_INC = \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
-    -I./transportModels/interfaceProperties/lnInclude \
+    -I./interfaceProperties/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/radiation/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/specie/lnInclude \

--- a/UEqn.H
+++ b/UEqn.H
@@ -27,7 +27,7 @@ if (pimple.momentumPredictor())
             ) * mesh.magSf()
         )
         -
-        fluid.divCapillaryStress()
+        fluid.divCapillaryStress(T)
     );
 
     fvOptions.correct(U);

--- a/createFields.H
+++ b/createFields.H
@@ -166,3 +166,17 @@
 
     Info<< "Creating field kinetic energy K\n" << endl;
     volScalarField K("K", 0.5*magSqr(U));
+
+    Info<< "Creating field divCapillaryStress\n" <<endl;
+    volVectorField divCapillaryStress
+    (
+        IOobject
+        (
+            "divCapillaryStress",
+            runTime.timeName(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
+        ),
+        fluid.divCapillaryStress(T)
+    );

--- a/interfaceProperties/Make/files
+++ b/interfaceProperties/Make/files
@@ -1,0 +1,11 @@
+interfaceProperties.C
+interfaceCompression/interfaceCompression.C
+
+alphaContactAngle/alphaContactAngleTwoPhaseFvPatchScalarField.C
+
+surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.C
+surfaceTensionModels/surfaceTensionModel/surfaceTensionModelNew.C
+surfaceTensionModels/constant/constantSurfaceTension.C
+surfaceTensionModels/temperatureDependent/temperatureDependentSurfaceTension.C
+
+LIB = $(FOAM_LIBBIN)/libinterfaceProperties

--- a/interfaceProperties/Make/options
+++ b/interfaceProperties/Make/options
@@ -1,0 +1,8 @@
+EXE_INC = \
+    -I$(LIB_SRC)/transportModels/twoPhaseMixture/lnInclude \
+    -I$(LIB_SRC)/transportModels/twoPhaseProperties/alphaContactAngle/alphaContactAngle \
+    -I$(LIB_SRC)/finiteVolume/lnInclude
+
+LIB_LIBS = \
+    -ltwoPhaseMixture \
+    -lfiniteVolume

--- a/interfaceProperties/alphaContactAngle/alphaContactAngleTwoPhaseFvPatchScalarField.C
+++ b/interfaceProperties/alphaContactAngle/alphaContactAngleTwoPhaseFvPatchScalarField.C
@@ -1,0 +1,167 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2011-2015 OpenFOAM Foundation
+    Copyright (C) 2019 OpenCFD Ltd.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "alphaContactAngleTwoPhaseFvPatchScalarField.H"
+#include "fvPatchFieldMapper.H"
+#include "volMesh.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+const Foam::Enum
+<
+    Foam::alphaContactAngleTwoPhaseFvPatchScalarField::limitControls
+>
+Foam::alphaContactAngleTwoPhaseFvPatchScalarField::limitControlNames_
+({
+    { limitControls::lcNone, "none" },
+    { limitControls::lcGradient, "gradient" },
+    { limitControls::lcZeroGradient, "zeroGradient" },
+    { limitControls::lcAlpha, "alpha" },
+});
+
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::alphaContactAngleTwoPhaseFvPatchScalarField::
+alphaContactAngleTwoPhaseFvPatchScalarField
+(
+    const fvPatch& p,
+    const DimensionedField<scalar, volMesh>& iF
+)
+:
+    fixedGradientFvPatchScalarField(p, iF),
+    limit_(lcZeroGradient)
+{}
+
+
+Foam::alphaContactAngleTwoPhaseFvPatchScalarField::
+alphaContactAngleTwoPhaseFvPatchScalarField
+(
+    const fvPatch& p,
+    const DimensionedField<scalar, volMesh>& iF,
+    const dictionary& dict
+)
+:
+    fixedGradientFvPatchScalarField(p, iF),
+    limit_(limitControlNames_.get("limit", dict))
+{
+    if (dict.found("gradient"))
+    {
+        gradient() = scalarField("gradient", dict, p.size());
+        fixedGradientFvPatchScalarField::updateCoeffs();
+        fixedGradientFvPatchScalarField::evaluate();
+    }
+    else
+    {
+        fvPatchField<scalar>::operator=(patchInternalField());
+        gradient() = 0.0;
+    }
+}
+
+
+Foam::alphaContactAngleTwoPhaseFvPatchScalarField::
+alphaContactAngleTwoPhaseFvPatchScalarField
+(
+    const alphaContactAngleTwoPhaseFvPatchScalarField& acpsf,
+    const fvPatch& p,
+    const DimensionedField<scalar, volMesh>& iF,
+    const fvPatchFieldMapper& mapper
+)
+:
+    fixedGradientFvPatchScalarField(acpsf, p, iF, mapper),
+    limit_(acpsf.limit_)
+{}
+
+
+Foam::alphaContactAngleTwoPhaseFvPatchScalarField::
+alphaContactAngleTwoPhaseFvPatchScalarField
+(
+    const alphaContactAngleTwoPhaseFvPatchScalarField& acpsf
+)
+:
+    fixedGradientFvPatchScalarField(acpsf),
+    limit_(acpsf.limit_)
+{}
+
+
+Foam::alphaContactAngleTwoPhaseFvPatchScalarField::
+alphaContactAngleTwoPhaseFvPatchScalarField
+(
+    const alphaContactAngleTwoPhaseFvPatchScalarField& acpsf,
+    const DimensionedField<scalar, volMesh>& iF
+)
+:
+    fixedGradientFvPatchScalarField(acpsf, iF),
+    limit_(acpsf.limit_)
+{}
+
+
+// * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+
+void Foam::alphaContactAngleTwoPhaseFvPatchScalarField::evaluate
+(
+    const Pstream::commsTypes
+)
+{
+    if (limit_ == lcGradient)
+    {
+        gradient() =
+        patch().deltaCoeffs()
+       *(
+           max(min
+           (
+               *this + gradient()/patch().deltaCoeffs(),
+               scalar(1)), scalar(0)
+           ) - *this
+       );
+    }
+    else if (limit_ == lcZeroGradient)
+    {
+        gradient() = 0.0;
+    }
+
+    fixedGradientFvPatchScalarField::evaluate();
+
+    if (limit_ == lcAlpha)
+    {
+        scalarField::operator=(max(min(*this, scalar(1)), scalar(0)));
+    }
+}
+
+
+void Foam::alphaContactAngleTwoPhaseFvPatchScalarField::write
+(
+    Ostream& os
+) const
+{
+    fixedGradientFvPatchScalarField::write(os);
+    os.writeEntry("limit", limitControlNames_[limit_]);
+}
+
+
+// ************************************************************************* //

--- a/interfaceProperties/alphaContactAngle/alphaContactAngleTwoPhaseFvPatchScalarField.H
+++ b/interfaceProperties/alphaContactAngle/alphaContactAngleTwoPhaseFvPatchScalarField.H
@@ -1,0 +1,167 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2011-2017 OpenFOAM Foundation
+    Copyright (C) 2019 OpenCFD Ltd.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::alphaContactAngleTwoPhaseFvPatchScalarField
+
+Group
+    grpWallBoundaryConditions grpGenericBoundaryConditions
+
+Description
+    Abstract base class for two-phase alphaContactAngle boundary conditions.
+
+    Derived classes must implement the theta() function which returns the
+    wall contact angle field.
+
+    The essential entry "limit" controls the gradient of alpha1 on the wall:
+      - none - Calculate the gradient from the contact-angle without limiter
+      - gradient - Limit the wall-gradient such that alpha1 remains bounded
+        on the wall
+      - alpha - Bound the calculated alpha1 on the wall
+      - zeroGradient - Set the gradient of alpha1 to 0 on the wall, i.e.
+        reproduce previous behaviour, the pressure BCs can be left as before.
+
+    Note that if any of the first three options are used the boundary condition
+    on \c p_rgh must set to guarantee that the flux is corrected to be zero at
+    the wall e.g.:
+
+    \verbatim
+    <patchName>
+    {
+        type            alphaContactAngle;
+        limit           none;
+    }
+    \endverbatim
+
+SourceFiles
+    alphaContactAngleTwoPhaseFvPatchScalarField.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef alphaContactAngleTwoPhaseFvPatchScalarField_H
+#define alphaContactAngleTwoPhaseFvPatchScalarField_H
+
+#include "fixedGradientFvPatchFields.H"
+#include "fvsPatchFields.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+         Class alphaContactAngleTwoPhaseFvPatchScalarField Declaration
+\*---------------------------------------------------------------------------*/
+
+class alphaContactAngleTwoPhaseFvPatchScalarField
+:
+    public fixedGradientFvPatchScalarField
+{
+public:
+
+    // Abstract class, no runtime information
+
+    //- Alpha limit options
+    enum limitControls
+    {
+        lcNone,
+        lcGradient,
+        lcZeroGradient,
+        lcAlpha
+    };
+
+    static const Enum<limitControls> limitControlNames_;
+    limitControls limit_;
+
+    // Constructors
+
+        //- Construct from patch and internal field
+        alphaContactAngleTwoPhaseFvPatchScalarField
+        (
+            const fvPatch&,
+            const DimensionedField<scalar, volMesh>&
+        );
+
+        //- Construct from patch, internal field and dictionary
+        alphaContactAngleTwoPhaseFvPatchScalarField
+        (
+            const fvPatch&,
+            const DimensionedField<scalar, volMesh>&,
+            const dictionary&
+        );
+
+        //- Construct by mapping onto a new patch
+        alphaContactAngleTwoPhaseFvPatchScalarField
+        (
+            const alphaContactAngleTwoPhaseFvPatchScalarField&,
+            const fvPatch&,
+            const DimensionedField<scalar, volMesh>&,
+            const fvPatchFieldMapper&
+        );
+
+        //- Construct as copy
+        alphaContactAngleTwoPhaseFvPatchScalarField
+        (
+            const alphaContactAngleTwoPhaseFvPatchScalarField&
+        );
+
+        //- Construct as copy setting internal field reference
+        alphaContactAngleTwoPhaseFvPatchScalarField
+        (
+            const alphaContactAngleTwoPhaseFvPatchScalarField&,
+            const DimensionedField<scalar, volMesh>&
+        );
+
+
+    // Member functions
+
+        //- Return the contact angle
+        virtual tmp<scalarField> theta
+        (
+            const fvPatchVectorField& Up,
+            const fvsPatchVectorField& nHat
+        ) const = 0;
+
+        //- Evaluate the patch field
+        virtual void evaluate
+        (
+            const Pstream::commsTypes commsType=Pstream::commsTypes::blocking
+        );
+
+        //- Write
+        virtual void write(Ostream& os) const;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/interfaceProperties/interfaceCompression/interfaceCompression.C
+++ b/interfaceProperties/interfaceCompression/interfaceCompression.C
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2011 OpenFOAM Foundation
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "PhiScheme.H"
+#include "interfaceCompression.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    makePhiSurfaceInterpolationScheme
+    (
+        interfaceCompression,
+        interfaceCompressionLimiter,
+        scalar
+    )
+}
+
+// ************************************************************************* //

--- a/interfaceProperties/interfaceCompression/interfaceCompression.H
+++ b/interfaceProperties/interfaceCompression/interfaceCompression.H
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2011 OpenFOAM Foundation
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::interfaceCompressionLimiter
+
+Description
+    Interface compression scheme currently based on the generic limited
+    scheme although it does not use the NVD/TVD functions.
+
+SourceFiles
+    interfaceCompression.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef interfaceCompression_H
+#define interfaceCompression_H
+
+#include "vector.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                           Class interfaceCompressionWeight Declaration
+\*---------------------------------------------------------------------------*/
+
+class interfaceCompressionLimiter
+{
+
+public:
+
+    interfaceCompressionLimiter(Istream&)
+    {}
+
+    scalar limiter
+    (
+        const scalar cdWeight,
+        const scalar faceFlux,
+        const scalar phiP,
+        const scalar phiN,
+        const vector&,
+        const scalar
+    ) const
+    {
+        // Quadratic compression scheme
+        //return min(max(4*min(phiP*(1 - phiP), phiN*(1 - phiN)), 0), 1);
+
+        // Quartic compression scheme
+        return
+            min(max(
+            1 - max(sqr(1 - 4*phiP*(1 - phiP)), sqr(1 - 4*phiN*(1 - phiN))),
+            0), 1);
+    }
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/interfaceProperties/interfaceProperties.C
+++ b/interfaceProperties/interfaceProperties.C
@@ -1,0 +1,242 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2011-2017 OpenFOAM Foundation
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "interfaceProperties.H"
+#include "alphaContactAngleTwoPhaseFvPatchScalarField.H"
+#include "mathematicalConstants.H"
+#include "surfaceInterpolate.H"
+#include "fvcDiv.H"
+#include "fvcGrad.H"
+#include "fvcSnGrad.H"
+#include "unitConversion.H"
+
+// * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
+
+// Correction for the boundary condition on the unit normal nHat on
+// walls to produce the correct contact angle.
+
+// The dynamic contact angle is calculated from the component of the
+// velocity on the direction of the interface, parallel to the wall.
+
+void Foam::interfaceProperties::correctContactAngle
+(
+    surfaceVectorField::Boundary& nHatb,
+    const surfaceVectorField::Boundary& gradAlphaf
+) const
+{
+    const fvMesh& mesh = alpha1_.mesh();
+    const volScalarField::Boundary& abf = alpha1_.boundaryField();
+
+    const fvBoundaryMesh& boundary = mesh.boundary();
+
+    forAll(boundary, patchi)
+    {
+        if (isA<alphaContactAngleTwoPhaseFvPatchScalarField>(abf[patchi]))
+        {
+            alphaContactAngleTwoPhaseFvPatchScalarField& acap =
+                const_cast<alphaContactAngleTwoPhaseFvPatchScalarField&>
+                (
+                    refCast<const alphaContactAngleTwoPhaseFvPatchScalarField>
+                    (
+                        abf[patchi]
+                    )
+                );
+
+            fvsPatchVectorField& nHatp = nHatb[patchi];
+            const scalarField theta
+            (
+                degToRad() * acap.theta(U_.boundaryField()[patchi], nHatp)
+            );
+
+            const vectorField nf
+            (
+                boundary[patchi].nf()
+            );
+
+            // Reset nHatp to correspond to the contact angle
+
+            const scalarField a12(nHatp & nf);
+            const scalarField b1(cos(theta));
+
+            scalarField b2(nHatp.size());
+            forAll(b2, facei)
+            {
+                b2[facei] = cos(acos(a12[facei]) - theta[facei]);
+            }
+
+            const scalarField det(1.0 - a12*a12);
+
+            scalarField a((b1 - a12*b2)/det);
+            scalarField b((b2 - a12*b1)/det);
+
+            nHatp = a*nf + b*nHatp;
+            nHatp /= (mag(nHatp) + deltaN_.value());
+
+            acap.gradient() = (nf & nHatp)*mag(gradAlphaf[patchi]);
+            acap.evaluate();
+        }
+    }
+}
+
+
+void Foam::interfaceProperties::calculateK()
+{
+    const fvMesh& mesh = alpha1_.mesh();
+    const surfaceVectorField& Sf = mesh.Sf();
+
+    // Cell gradient of alpha
+    const volVectorField gradAlpha(fvc::grad(alpha1_, "nHat"));
+
+    // Interpolated face-gradient of alpha
+    surfaceVectorField gradAlphaf(fvc::interpolate(gradAlpha));
+
+    //gradAlphaf -=
+    //    (mesh.Sf()/mesh.magSf())
+    //   *(fvc::snGrad(alpha1_) - (mesh.Sf() & gradAlphaf)/mesh.magSf());
+
+    // Face unit interface normal
+    surfaceVectorField nHatfv(gradAlphaf/(mag(gradAlphaf) + deltaN_));
+    // surfaceVectorField nHatfv
+    // (
+    //     (gradAlphaf + deltaN_*vector(0, 0, 1)
+    //    *sign(gradAlphaf.component(vector::Z)))/(mag(gradAlphaf) + deltaN_)
+    // );
+    correctContactAngle(nHatfv.boundaryFieldRef(), gradAlphaf.boundaryField());
+
+    // Face unit interface normal flux
+    nHatf_ = nHatfv & Sf;
+
+    // Simple expression for curvature
+    K_ = -fvc::div(nHatf_);
+
+    // Complex expression for curvature.
+    // Correction is formally zero but numerically non-zero.
+    /*
+    volVectorField nHat(gradAlpha/(mag(gradAlpha) + deltaN_));
+    forAll(nHat.boundaryField(), patchi)
+    {
+        nHat.boundaryFieldRef()[patchi] = nHatfv.boundaryField()[patchi];
+    }
+
+    K_ = -fvc::div(nHatf_) + (nHat & fvc::grad(nHatfv) & nHat);
+    */
+}
+
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::interfaceProperties::interfaceProperties
+(
+    const volScalarField& alpha1,
+    const volVectorField& U,
+    const IOdictionary& dict
+)
+:
+    transportPropertiesDict_(dict),
+    cAlpha_
+    (
+        alpha1.mesh().solverDict(alpha1.name()).get<scalar>("cAlpha")
+    ),
+
+    sigmaPtr_(surfaceTensionModel::New(dict, alpha1.mesh())),
+
+    deltaN_
+    (
+        "deltaN",
+        1e-8/cbrt(average(alpha1.mesh().V()))
+    ),
+
+    alpha1_(alpha1),
+    U_(U),
+
+    nHatf_
+    (
+        IOobject
+        (
+            "nHatf",
+            alpha1_.time().timeName(),
+            alpha1_.mesh()
+        ),
+        alpha1_.mesh(),
+        dimensionedScalar(dimArea, Zero)
+    ),
+
+    K_
+    (
+        IOobject
+        (
+            "interfaceProperties:K",
+            alpha1_.time().timeName(),
+            alpha1_.mesh()
+        ),
+        alpha1_.mesh(),
+        dimensionedScalar(dimless/dimLength, Zero)
+    )
+{
+    calculateK();
+}
+
+
+// * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * * //
+
+Foam::tmp<Foam::volScalarField>
+Foam::interfaceProperties::sigmaK() const
+{
+    return sigmaPtr_->sigma()*K_;
+}
+
+
+Foam::tmp<Foam::surfaceScalarField>
+Foam::interfaceProperties::surfaceTensionForce() const
+{
+    return fvc::interpolate(sigmaK())*fvc::snGrad(alpha1_);
+}
+
+
+Foam::tmp<Foam::volScalarField>
+Foam::interfaceProperties::nearInterface() const
+{
+    return pos0(alpha1_ - 0.01)*pos0(0.99 - alpha1_);
+}
+
+
+void Foam::interfaceProperties::correct()
+{
+    calculateK();
+}
+
+
+bool Foam::interfaceProperties::read()
+{
+    alpha1_.mesh().solverDict(alpha1_.name()).readEntry("cAlpha", cAlpha_);
+    sigmaPtr_->readDict(transportPropertiesDict_);
+
+    return true;
+}
+
+
+// ************************************************************************* //

--- a/interfaceProperties/interfaceProperties.H
+++ b/interfaceProperties/interfaceProperties.H
@@ -1,0 +1,154 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2011-2017 OpenFOAM Foundation
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::interfaceProperties
+
+Description
+    Contains the interface properties.
+
+    Properties to aid interFoam:
+    -# Correct the alpha boundary condition for dynamic contact angle.
+    -# Calculate interface curvature.
+
+SourceFiles
+    interfaceProperties.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef interfaceProperties_H
+#define interfaceProperties_H
+
+#include "IOdictionary.H"
+#include "surfaceTensionModel.H"
+#include "volFields.H"
+#include "surfaceFields.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                     Class interfaceProperties Declaration
+\*---------------------------------------------------------------------------*/
+
+class interfaceProperties
+{
+    // Private data
+
+        //- Keep a reference to the transportProperties dictionary
+        const dictionary& transportPropertiesDict_;
+
+        //- Compression coefficient
+        scalar cAlpha_;
+
+        //- Surface tension
+        autoPtr<surfaceTensionModel> sigmaPtr_;
+
+        //- Stabilisation for normalisation of the interface normal
+        const dimensionedScalar deltaN_;
+
+        const volScalarField& alpha1_;
+        const volVectorField& U_;
+        surfaceScalarField nHatf_;
+        volScalarField K_;
+
+
+    // Private Member Functions
+
+        //- No copy construct
+        interfaceProperties(const interfaceProperties&) = delete;
+
+        //- No copy assignment
+        void operator=(const interfaceProperties&) = delete;
+
+        //- Correction for the boundary condition on the unit normal nHat on
+        //  walls to produce the correct contact dynamic angle
+        //  calculated from the component of U parallel to the wall
+        void correctContactAngle
+        (
+            surfaceVectorField::Boundary& nHat,
+            const surfaceVectorField::Boundary& gradAlphaf
+        ) const;
+
+        //- Re-calculate the interface curvature
+        void calculateK();
+
+
+public:
+
+    // Constructors
+
+        //- Construct from volume fraction field gamma and IOdictionary
+        interfaceProperties
+        (
+            const volScalarField& alpha1,
+            const volVectorField& U,
+            const IOdictionary&
+        );
+
+
+    // Member Functions
+
+        scalar cAlpha() const
+        {
+            return cAlpha_;
+        }
+
+        const dimensionedScalar& deltaN() const
+        {
+            return deltaN_;
+        }
+
+        const surfaceScalarField& nHatf() const
+        {
+            return nHatf_;
+        }
+
+        tmp<volScalarField> sigmaK() const;
+
+        tmp<surfaceScalarField> surfaceTensionForce() const;
+
+        //- Indicator of the proximity of the interface
+        //  Field values are 1 near and 0 away for the interface.
+        tmp<volScalarField> nearInterface() const;
+
+        void correct();
+
+        //- Read transportProperties dictionary
+        bool read();
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.C
+++ b/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.C
@@ -1,0 +1,113 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2017 OpenFOAM Foundation
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "constantSurfaceTension.H"
+#include "volFields.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace surfaceTensionModels
+{
+    defineTypeNameAndDebug(constant, 0);
+    addToRunTimeSelectionTable(surfaceTensionModel, constant, dictionary);
+}
+}
+
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::surfaceTensionModels::constant::constant
+(
+    const dictionary& dict,
+    const fvMesh& mesh
+)
+:
+    surfaceTensionModel(mesh),
+    sigma_("sigma", dimMass/sqr(dimTime), dict)
+{}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::surfaceTensionModels::constant::~constant()
+{}
+
+
+// * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+
+Foam::tmp<Foam::volScalarField>
+Foam::surfaceTensionModels::constant::sigma() const
+{
+    return tmp<volScalarField>::New
+    (
+        IOobject
+        (
+            "sigma",
+            mesh_.time().timeName(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE,
+            false
+        ),
+        mesh_,
+        sigma_
+    );
+}
+
+
+bool Foam::surfaceTensionModels::constant::readDict(const dictionary& dict)
+{
+    // Handle sub-dictionary format as a special case
+    if (dict.isDict("sigma"))
+    {
+        dict.subDict("sigma").readEntry("sigma", sigma_);
+    }
+    else
+    {
+        dict.readEntry("sigma", sigma_);
+    }
+
+    return true;
+}
+
+
+bool Foam::surfaceTensionModels::constant::writeData(Ostream& os) const
+{
+    if (surfaceTensionModel::writeData(os))
+    {
+        os  << sigma_ << token::END_STATEMENT << nl;
+        return os.good();
+    }
+
+    return false;
+}
+
+
+// ************************************************************************* //

--- a/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.C
+++ b/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.C
@@ -50,7 +50,8 @@ Foam::surfaceTensionModels::constant::constant
 )
 :
     surfaceTensionModel(mesh),
-    sigma_("sigma", dimMass/sqr(dimTime), dict)
+    sigma_("sigma", dimMass/sqr(dimTime), dict),
+    dSigmadT_("dSigmadT", dimMass/sqr(dimTime)/dimTemperature, dict)
 {}
 
 

--- a/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.C
+++ b/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.C
@@ -81,6 +81,29 @@ Foam::surfaceTensionModels::constant::sigma() const
     );
 }
 
+Foam::tmp<Foam::volScalarField>
+Foam::surfaceTensionModels::constant::dSigmadT() const
+{
+    /*
+    return tmp<volScalarField>::New
+    (
+        IOobject
+        (
+            "dSigmadT",
+            mesh_.time().timeName(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE,
+            false
+        ),
+        mesh_,
+        dSigmadT_
+    );
+    */
+    return 0;
+}
+
+
 
 bool Foam::surfaceTensionModels::constant::readDict(const dictionary& dict)
 {

--- a/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.H
+++ b/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.H
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2017 OpenFOAM Foundation
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::surfaceTensionModels::constant
+
+Description
+    Uniform constant surface tension model.
+
+Usage
+    Example of the surface tension specification:
+    \verbatim
+        sigma
+        {
+            type                constant;
+            sigma               0.07;
+        }
+    \endverbatim
+
+See also
+    Foam::surfaceTensionModel
+
+SourceFiles
+    constantSurfaceTension.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef constantSurfaceTension_H
+#define constantSurfaceTension_H
+
+#include "surfaceTensionModel.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+namespace surfaceTensionModels
+{
+
+/*---------------------------------------------------------------------------*\
+                           Class constant Declaration
+\*---------------------------------------------------------------------------*/
+
+class constant
+:
+    public surfaceTensionModel
+{
+    // Private data
+
+        //- Surface tension coefficient
+        dimensionedScalar sigma_;
+
+
+public:
+
+    //- Runtime type information
+    TypeName("constant");
+
+
+    // Constructors
+
+        //- Construct from dictionary and mesh
+        constant
+        (
+            const dictionary& dict,
+            const fvMesh& mesh
+        );
+
+
+    //- Destructor
+    virtual ~constant();
+
+
+    // Member Functions
+
+        //- Surface tension coefficient
+        virtual tmp<volScalarField> sigma() const;
+
+        //- Update surface tension coefficient from given dictionary
+        virtual bool readDict(const dictionary& dict);
+
+        //- Write in dictionary format
+        virtual bool writeData(Ostream& os) const;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace surfaceTensionModels
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.H
+++ b/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.H
@@ -73,6 +73,8 @@ class constant
         //- Surface tension coefficient
         dimensionedScalar sigma_;
 
+        //- Surface tension temperature coefficient - needs to be zero here
+    	dimensionedScalar dSigmadT_;
 
 public:
 

--- a/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.H
+++ b/interfaceProperties/surfaceTensionModels/constant/constantSurfaceTension.H
@@ -99,6 +99,9 @@ public:
         //- Surface tension coefficient
         virtual tmp<volScalarField> sigma() const;
 
+        //- Surface tension temperature coefficient - needs to be zero here
+	    virtual tmp<volScalarField> dSigmadT() const;
+
         //- Update surface tension coefficient from given dictionary
         virtual bool readDict(const dictionary& dict);
 

--- a/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.C
+++ b/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.C
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2017 OpenFOAM Foundation
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "surfaceTensionModel.H"
+#include "fvMesh.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    defineTypeNameAndDebug(surfaceTensionModel, 0);
+    defineRunTimeSelectionTable(surfaceTensionModel, dictionary);
+}
+
+const Foam::dimensionSet Foam::surfaceTensionModel::dimSigma(1, 0, -2, 0, 0);
+
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::surfaceTensionModel::surfaceTensionModel(const fvMesh& mesh)
+:
+    regIOobject
+    (
+        IOobject
+        (
+            typeName, mesh.name(),
+            mesh.time().timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        )
+    ),
+    mesh_(mesh)
+{}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::surfaceTensionModel::~surfaceTensionModel()
+{}
+
+
+// * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+
+bool Foam::surfaceTensionModel::writeData(Ostream& os) const
+{
+    return os.good();
+}
+
+
+// ************************************************************************* //

--- a/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.C
+++ b/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.C
@@ -37,6 +37,8 @@ namespace Foam
 }
 
 const Foam::dimensionSet Foam::surfaceTensionModel::dimSigma(1, 0, -2, 0, 0);
+// dSigmadT has different dim than sigma
+const Foam::dimensionSet Foam::surfaceTensionModel::dimdSigmadT(1, 0, -2, -1, 0);
 
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //

--- a/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.H
+++ b/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.H
@@ -1,0 +1,163 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2017 OpenFOAM Foundation
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::surfaceTensionModel
+
+Description
+    Abstract base-class for surface tension models which return the surface
+    tension coefficient field.
+
+Usage
+    Example of the surface tension specification:
+    \verbatim
+        sigma
+        {
+            type                <surface tension model type>;
+            <coefficient name>  <coefficient value>;
+            .
+            .
+            .
+        }
+    \endverbatim
+    For simplicity and backward-compatibility the constant value format is
+    also supported, e.g.
+    \verbatim
+        sigma           0.07;
+    \endverbatim
+
+SourceFiles
+    surfaceTensionModel.C
+    newSurfaceTensionModel.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef surfaceTensionModel_H
+#define surfaceTensionModel_H
+
+#include "regIOobject.H"
+#include "dimensionedTypes.H"
+#include "volFieldsFwd.H"
+#include "runTimeSelectionTables.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+class fvMesh;
+
+/*---------------------------------------------------------------------------*\
+                           Class surfaceTensionModel Declaration
+\*---------------------------------------------------------------------------*/
+
+class surfaceTensionModel
+:
+    public regIOobject
+{
+protected:
+
+    // Protected member data
+
+        //- Reference to mesh
+        const fvMesh& mesh_;
+
+
+    // Protected member functions
+
+        static const dictionary& sigmaDict(const dictionary& dict)
+        {
+            return dict.subDict("sigma");
+        }
+
+
+public:
+
+    //- Runtime type information
+    TypeName("surfaceTensionModel");
+
+
+    // Declare runtime construction
+
+        declareRunTimeSelectionTable
+        (
+            autoPtr,
+            surfaceTensionModel,
+            dictionary,
+            (
+                const dictionary& dict,
+                const fvMesh& mesh
+            ),
+            (dict, mesh)
+        );
+
+
+    // Static data members
+
+        //- Surface tension coefficient dimensions
+        static const dimensionSet dimSigma;
+
+
+    // Constructors
+
+        // Construct from mesh
+        surfaceTensionModel(const fvMesh& mesh);
+
+
+    //- Destructor
+    virtual ~surfaceTensionModel();
+
+
+    // Selectors
+
+        static autoPtr<surfaceTensionModel> New
+        (
+            const dictionary& dict,
+            const fvMesh& mesh
+        );
+
+
+    // Member Functions
+
+        //- Surface tension coefficient
+        virtual tmp<volScalarField> sigma() const = 0;
+
+        //- Update surface tension coefficient from given dictionary
+        virtual bool readDict(const dictionary& dict) = 0;
+
+        //- Write in dictionary format
+        virtual bool writeData(Ostream& os) const = 0;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.H
+++ b/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.H
@@ -144,6 +144,9 @@ public:
         //- Surface tension coefficient
         virtual tmp<volScalarField> sigma() const = 0;
 
+        //- Surface tension temperature coefficient
+        virtual tmp<volScalarField> dSigmadT() const = 0;
+
         //- Update surface tension coefficient from given dictionary
         virtual bool readDict(const dictionary& dict) = 0;
 

--- a/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.H
+++ b/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.H
@@ -119,6 +119,8 @@ public:
         //- Surface tension coefficient dimensions
         static const dimensionSet dimSigma;
 
+        //- Surface tension temperature coefficient dimensions
+        static const dimensionSet dimdSigmadT;
 
     // Constructors
 

--- a/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModelNew.C
+++ b/interfaceProperties/surfaceTensionModels/surfaceTensionModel/surfaceTensionModelNew.C
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2017 OpenFOAM Foundation
+    Copyright (C) 2019 OpenCFD Ltd.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "surfaceTensionModel.H"
+#include "constantSurfaceTension.H"
+
+// * * * * * * * * * * * * * * * * Selector  * * * * * * * * * * * * * * * * //
+
+Foam::autoPtr<Foam::surfaceTensionModel> Foam::surfaceTensionModel::New
+(
+    const dictionary& dict,
+    const fvMesh& mesh
+)
+{
+    if (dict.isDict("sigma"))
+    {
+        const dictionary& sigmaDict = surfaceTensionModel::sigmaDict(dict);
+
+        const word modelType(sigmaDict.get<word>("type"));
+
+        Info<< "Selecting surfaceTensionModel " << modelType << endl;
+
+        auto cstrIter = dictionaryConstructorTablePtr_->cfind(modelType);
+
+        if (!cstrIter.found())
+        {
+            FatalIOErrorInLookup
+            (
+                dict,
+                "surfaceTensionModel",
+                modelType,
+                *dictionaryConstructorTablePtr_
+            ) << exit(FatalIOError);
+        }
+
+        return cstrIter()(sigmaDict, mesh);
+    }
+
+    return autoPtr<surfaceTensionModel>
+    (
+        new surfaceTensionModels::constant(dict, mesh)
+    );
+}
+
+
+// ************************************************************************* //

--- a/interfaceProperties/surfaceTensionModels/temperatureDependent/temperatureDependentSurfaceTension.C
+++ b/interfaceProperties/surfaceTensionModels/temperatureDependent/temperatureDependentSurfaceTension.C
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2017 OpenFOAM Foundation
+    Copyright (C) 2020 OpenCFD Ltd.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "temperatureDependentSurfaceTension.H"
+#include "volFields.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace surfaceTensionModels
+{
+    defineTypeNameAndDebug(temperatureDependent, 0);
+    addToRunTimeSelectionTable
+    (
+        surfaceTensionModel,
+        temperatureDependent,
+        dictionary
+    );
+}
+}
+
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::surfaceTensionModels::temperatureDependent::temperatureDependent
+(
+    const dictionary& dict,
+    const fvMesh& mesh
+)
+:
+    surfaceTensionModel(mesh),
+    TName_(dict.getOrDefault<word>("T", "T")),
+    sigma_(Function1<scalar>::New("sigma", dict))
+{}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::surfaceTensionModels::temperatureDependent::~temperatureDependent()
+{}
+
+
+// * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+
+Foam::tmp<Foam::volScalarField>
+Foam::surfaceTensionModels::temperatureDependent::sigma() const
+{
+    auto tsigma = tmp<volScalarField>::New
+    (
+        IOobject
+        (
+            "sigma",
+            mesh_.time().timeName(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE,
+            false
+        ),
+        mesh_,
+        dimSigma
+    );
+    auto& sigma = tsigma.ref();
+
+    const volScalarField& T = mesh_.lookupObject<volScalarField>(TName_);
+
+    sigma.field() = sigma_->value(T.field());
+
+    volScalarField::Boundary& sigmaBf = sigma.boundaryFieldRef();
+    const volScalarField::Boundary& TBf = T.boundaryField();
+
+    forAll(sigmaBf, patchi)
+    {
+        sigmaBf[patchi] = sigma_->value(TBf[patchi]);
+    }
+
+    return tsigma;
+}
+
+
+bool Foam::surfaceTensionModels::temperatureDependent::readDict
+(
+    const dictionary& dict
+)
+{
+    const dictionary& sigmaDict = surfaceTensionModel::sigmaDict(dict);
+
+    TName_ = sigmaDict.getOrDefault<word>("T", "T");
+    sigma_ = Function1<scalar>::New("sigma", sigmaDict);
+
+    return true;
+}
+
+
+bool Foam::surfaceTensionModels::temperatureDependent::writeData
+(
+    Ostream& os
+) const
+{
+    if (surfaceTensionModel::writeData(os))
+    {
+        os  << sigma_() << token::END_STATEMENT << nl;
+        return os.good();
+    }
+
+    return false;
+}
+
+
+// ************************************************************************* //

--- a/interfaceProperties/surfaceTensionModels/temperatureDependent/temperatureDependentSurfaceTension.C
+++ b/interfaceProperties/surfaceTensionModels/temperatureDependent/temperatureDependentSurfaceTension.C
@@ -120,7 +120,7 @@ Foam::surfaceTensionModels::temperatureDependent::dSigmadT() const
             false
         ),
         mesh_,
-        dSigmadT_
+        dimdSigmadT
     );
     auto& dSigmadT = tdSigmadT.ref();
 

--- a/interfaceProperties/surfaceTensionModels/temperatureDependent/temperatureDependentSurfaceTension.C
+++ b/interfaceProperties/surfaceTensionModels/temperatureDependent/temperatureDependentSurfaceTension.C
@@ -151,6 +151,10 @@ bool Foam::surfaceTensionModels::temperatureDependent::readDict
     TName_ = sigmaDict.getOrDefault<word>("T", "T");
     sigma_ = Function1<scalar>::New("sigma", sigmaDict);
 
+    // Read surface tension temperature coefficient
+    // Handle sub-dictionary format as a special case
+    dSigmadT_ = Function1<scalar>::New("dSigmadT", sigmaDict);
+
     return true;
 }
 

--- a/interfaceProperties/surfaceTensionModels/temperatureDependent/temperatureDependentSurfaceTension.H
+++ b/interfaceProperties/surfaceTensionModels/temperatureDependent/temperatureDependentSurfaceTension.H
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2017 OpenFOAM Foundation
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::surfaceTensionModels::temperatureDependent
+
+Description
+    Temperature-dependent surface tension model.
+
+    The surface tension is evaluated from the specified Foam::Function1 for the
+    temperature field looked-up from the mesh database the name of which
+    may optionally be provided.
+
+Usage
+    \table
+        Property     | Description               | Required    | Default value
+        T            | Temperature field name    | no          | T
+        sigma        | Surface tension function  | yes         |
+    \endtable
+
+    Example of the surface tension specification:
+    \verbatim
+        sigma
+        {
+            type                temperatureDependent;
+            sigma               constant 0.07;
+        }
+    \endverbatim
+
+See also
+    Foam::surfaceTensionModel
+    Foam::Function1
+
+SourceFiles
+    temperatureDependentSurfaceTension.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef temperatureDependentSurfaceTension_H
+#define temperatureDependentSurfaceTension_H
+
+#include "surfaceTensionModel.H"
+#include "Function1.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+namespace surfaceTensionModels
+{
+
+/*---------------------------------------------------------------------------*\
+                           Class temperatureDependent Declaration
+\*---------------------------------------------------------------------------*/
+
+class temperatureDependent
+:
+    public surfaceTensionModel
+{
+    // Private data
+
+        //- Name of temperature field, default = "T"
+        word TName_;
+
+        //- Surface-tension function
+        autoPtr<Function1<scalar>> sigma_;
+
+
+public:
+
+    //- Runtime type information
+    TypeName("temperatureDependent");
+
+
+    // Constructors
+
+        //- Construct from dictionary and mesh
+        temperatureDependent
+        (
+            const dictionary& dict,
+            const fvMesh& mesh
+        );
+
+
+    //- Destructor
+    virtual ~temperatureDependent();
+
+
+    // Member Functions
+
+        //- Surface tension coefficient
+        virtual tmp<volScalarField> sigma() const;
+
+        //- Update surface tension coefficient from given dictionary
+        virtual bool readDict(const dictionary& dict);
+
+        //- Write in dictionary format
+        virtual bool writeData(Ostream& os) const;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace surfaceTensionModels
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/interfaceProperties/surfaceTensionModels/temperatureDependent/temperatureDependentSurfaceTension.H
+++ b/interfaceProperties/surfaceTensionModels/temperatureDependent/temperatureDependentSurfaceTension.H
@@ -88,6 +88,8 @@ class temperatureDependent
         //- Surface-tension function
         autoPtr<Function1<scalar>> sigma_;
 
+        //- Surface-tension temperature coefficient
+	    autoPtr<Function1<scalar>> dSigmadT_;
 
 public:
 
@@ -113,6 +115,9 @@ public:
 
         //- Surface tension coefficient
         virtual tmp<volScalarField> sigma() const;
+
+        //- Surface tension temperature coefficient
+	    virtual tmp<volScalarField> dSigmadT() const;
 
         //- Update surface tension coefficient from given dictionary
         virtual bool readDict(const dictionary& dict);

--- a/pEqn.H
+++ b/pEqn.H
@@ -31,6 +31,7 @@
     (
         (
             fluid.surfaceTensionForce()
+            //fvc::interpolate(mag(fluid.divCapillaryStress()))
           - ghf*fvc::snGrad(rho)
         )*rAUf*mesh.magSf()
     );

--- a/phasesSystem/Make/options
+++ b/phasesSystem/Make/options
@@ -10,7 +10,7 @@ EXE_INC = \
     -I$(LIB_SRC)/transportModels \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
     -I$(LIB_SRC)/transportModels/incompressible/lnInclude \
-    -I$(LIB_SRC)/transportModels/interfaceProperties/lnInclude \
+    -I../interfaceProperties/lnInclude \
     -I$(LIB_SRC)/transportModels/geometricVoF/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \

--- a/phasesSystem/interfaceModels/surfaceTensionModels/constantSurfaceTensionCoefficient/constantSurfaceTensionCoefficient.C
+++ b/phasesSystem/interfaceModels/surfaceTensionModels/constantSurfaceTensionCoefficient/constantSurfaceTensionCoefficient.C
@@ -57,7 +57,8 @@ constantSurfaceTensionCoefficient
 )
 :
     surfaceTensionModel(dict, pair, registerObject),
-    sigma_("sigma", dimMass/sqr(dimTime), dict)
+    sigma_("sigma", dimMass/sqr(dimTime), dict),
+    dSigmadT_("dSigmadT", dimMass/sqr(dimTime)/dimTemperature, dict)
 {}
 
 
@@ -80,6 +81,28 @@ Foam::surfaceTensionModels::constantSurfaceTensionCoefficient::sigma() const
             mesh,
             sigma_
         );
+}
+
+Foam::tmp<Foam::volScalarField>
+Foam::surfaceTensionModels::constant::dSigmadT() const
+{
+    /*
+    return tmp<volScalarField>::New
+    (
+        IOobject
+        (
+            "dSigmadT",
+            mesh_.time().timeName(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE,
+            false
+        ),
+        mesh_,
+        dSigmadT_
+    );
+    */
+    return 0;
 }
 
 

--- a/phasesSystem/interfaceModels/surfaceTensionModels/constantSurfaceTensionCoefficient/constantSurfaceTensionCoefficient.H
+++ b/phasesSystem/interfaceModels/surfaceTensionModels/constantSurfaceTensionCoefficient/constantSurfaceTensionCoefficient.H
@@ -59,6 +59,8 @@ class constantSurfaceTensionCoefficient
         //- Constant surface tension value
         const dimensionedScalar sigma_;
 
+        //- dSigmadT must be zero here
+        const dimensionedScalar dSigmadT_;
 
 public:
 

--- a/phasesSystem/interfaceModels/surfaceTensionModels/constantSurfaceTensionCoefficient/constantSurfaceTensionCoefficient.H
+++ b/phasesSystem/interfaceModels/surfaceTensionModels/constantSurfaceTensionCoefficient/constantSurfaceTensionCoefficient.H
@@ -85,6 +85,9 @@ public:
 
         //- Aspect ratio
         virtual tmp<volScalarField> sigma() const;
+
+        //- Surface tension temperature coefficient
+        virtual tmp<volScalarField> dSigmadT() const = 0;
 };
 
 

--- a/phasesSystem/interfaceModels/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.H
+++ b/phasesSystem/interfaceModels/surfaceTensionModels/surfaceTensionModel/surfaceTensionModel.H
@@ -114,6 +114,9 @@ public:
         //- Surface tension
         virtual tmp<volScalarField> sigma() const = 0;
 
+        //- Surface tension temperature coefficient
+        virtual tmp<volScalarField> dSigmadT() const = 0;
+
         //- Dummy write for regIOobject
         bool writeData(Ostream& os) const;
 };

--- a/phasesSystem/phaseSystem/phaseSystem.C
+++ b/phasesSystem/phaseSystem/phaseSystem.C
@@ -1054,9 +1054,6 @@ Foam::phaseSystem::divCapillaryStress(
 
     auto& cst = tcst.ref();
 
-    // Identity tensor / Kronecker delta
-    tensor I(1,0,0,0,1,0,0,0,1);
-
     /*
         Implementation of the capillary stress tensor
         with the Continuous Surface Stress Method
@@ -1090,14 +1087,15 @@ Foam::phaseSystem::divCapillaryStress(
                     (
                         (
                             (
-                                I
+                                tensor::I
                                 -
                                 nHat(alpha1,alpha2) * nHat(alpha1,alpha2)
                             )
                             &
-                            fvc::grad
+                            fvc::grad(T)
+                            *
                             (
-                                surfaceTensionCoeff
+                                dSigmadT
                                 (
                                     phasePairKey(iter1()->name(), iter2()->name())
                                 )
@@ -1158,6 +1156,12 @@ Foam::phaseSystem::surfaceTensionCoeff(const phasePairKey& key) const
     return surfaceTensionModels_[key]->sigma();
 }
 
+//- Read the surface tension temperature dependence
+Foam::tmp<Foam::volScalarField>
+Foam::phaseSystem::dSigmadT(const phasePairKey& key) const
+{
+    return surfaceTensionModels_[key]->dSigmadT();
+}
 
 Foam::tmp<Foam::volScalarField> Foam::phaseSystem::coeffs
 (

--- a/phasesSystem/phaseSystem/phaseSystem.C
+++ b/phasesSystem/phaseSystem/phaseSystem.C
@@ -1086,14 +1086,13 @@ Foam::phaseSystem::divCapillaryStress(
                     *
                     (
                         (
+                            fvc::grad(T)
+                            &
                             (
                                 tensor::I
                                 -
                                 nHat(alpha1,alpha2) * nHat(alpha1,alpha2)
                             )
-                            &
-                            fvc::grad(T)
-                            
                         )
                         *
                         dSigmadT

--- a/phasesSystem/phaseSystem/phaseSystem.C
+++ b/phasesSystem/phaseSystem/phaseSystem.C
@@ -1094,11 +1094,9 @@ Foam::phaseSystem::divCapillaryStress(
                             &
                             fvc::grad(T)
                             *
+                            dSigmadT
                             (
-                                dSigmadT
-                                (
-                                    phasePairKey(iter1()->name(), iter2()->name())
-                                )
+                                phasePairKey(iter1()->name(), iter2()->name())
                             )
                         )
                     )

--- a/phasesSystem/phaseSystem/phaseSystem.C
+++ b/phasesSystem/phaseSystem/phaseSystem.C
@@ -1036,7 +1036,9 @@ Foam::phaseSystem::surfaceTensionForce() const
 }
 
 Foam::tmp<Foam::volVectorField>
-Foam::phaseSystem::divCapillaryStress() const
+Foam::phaseSystem::divCapillaryStress(
+    const volScalarField& T
+) const
 {
     auto tcst = tmp<volVectorField>::New
     (
@@ -1051,7 +1053,9 @@ Foam::phaseSystem::divCapillaryStress() const
     );
 
     auto& cst = tcst.ref();
-    //cst.setOriented();
+
+    // Identity tensor / Kronecker delta
+    tensor I(1,0,0,0,1,0,0,0,1);
 
     /*
         Implementation of the capillary stress tensor
@@ -1086,7 +1090,7 @@ Foam::phaseSystem::divCapillaryStress() const
                     (
                         (
                             (
-                                tensor::I
+                                I
                                 -
                                 nHat(alpha1,alpha2) * nHat(alpha1,alpha2)
                             )
@@ -1108,7 +1112,7 @@ Foam::phaseSystem::divCapillaryStress() const
                     *
                     fvc::div
                     (
-                        tensor::I
+                        I
                         -
                         nHat(alpha1,alpha2) * nHat(alpha1,alpha2)
                     )

--- a/phasesSystem/phaseSystem/phaseSystem.C
+++ b/phasesSystem/phaseSystem/phaseSystem.C
@@ -1093,11 +1093,12 @@ Foam::phaseSystem::divCapillaryStress(
                             )
                             &
                             fvc::grad(T)
-                            *
-                            dSigmadT
-                            (
-                                phasePairKey(iter1()->name(), iter2()->name())
-                            )
+                            
+                        )
+                        *
+                        dSigmadT
+                        (
+                            phasePairKey(iter1()->name(), iter2()->name())
                         )
                     )
                     +

--- a/phasesSystem/phaseSystem/phaseSystem.C
+++ b/phasesSystem/phaseSystem/phaseSystem.C
@@ -1058,9 +1058,6 @@ Foam::phaseSystem::divCapillaryStress(
         Implementation of the capillary stress tensor
         with the Continuous Surface Stress Method
         iaw Brackbill et al., 1992, Lafaurie et al. 1994
-        T = - sigma * (I - n x n) * mag(grad(alpha))
-          = - sigma * (I * mag(grad(alpha)) - (grad(alpha) x grad(alpha)) /
-            mag(grad(alpha)))
     */
 
     if (surfaceTensionModels_.size())
@@ -1084,37 +1081,32 @@ Foam::phaseSystem::divCapillaryStress(
                 cst +=
                     mag(gradAlphaf)
                     *
+                    /* Tangential (Marangoni) force */
                     (
                         (
                             fvc::grad(T)
-                            &
-                            (
-                                tensor::I
-                                -
-                                nHat(alpha1,alpha2) * nHat(alpha1,alpha2)
+                            -
+                            nHat(alpha1,alpha2) * (
+                                nHat(alpha1,alpha2)
+                                & fvc::grad(T)
                             )
                         )
                         *
-                        dSigmadT
-                        (
+                        dSigmadT(
                             phasePairKey(iter1()->name(), iter2()->name())
                         )
-                    )
-                    +
-                    surfaceTensionCoeff
-                    (
-                        phasePairKey(iter1()->name(), iter2()->name())
-                    )
-                    *
-                    fvc::div
-                    (
-                        I
-                        -
-                        nHat(alpha1,alpha2) * nHat(alpha1,alpha2)
-                    )
-                    *
-                    mag(gradAlphaf)
-                    ;
+                        +
+                    /* Normal surface tension force */
+                        surfaceTensionCoeff(
+                            phasePairKey(iter1()->name(), iter2()->name())
+                        )
+                        *
+                        fvc::div(
+                            tensor::I
+                            -
+                            nHat(alpha1,alpha2) * nHat(alpha1,alpha2)
+                        )
+                    );
             }
         }
     }

--- a/phasesSystem/phaseSystem/phaseSystem.H
+++ b/phasesSystem/phaseSystem/phaseSystem.H
@@ -491,7 +491,9 @@ public:
         ) const;
 
         //- Calculate divergence of the capillary stress tensor
-	    tmp<volVectorField> divCapillaryStress() const;
+	    tmp<volVectorField> divCapillaryStress(
+            const volScalarField& T
+        ) const;
 
 
         //- Return coefficients (1/rho)

--- a/phasesSystem/phaseSystem/phaseSystem.H
+++ b/phasesSystem/phaseSystem/phaseSystem.H
@@ -495,6 +495,11 @@ public:
             const volScalarField& T
         ) const;
 
+        //- Return the surface tension temperature dependence
+        virtual tmp<volScalarField> dSigmadT
+        (
+            const phasePairKey& key
+        ) const;
 
         //- Return coefficients (1/rho)
         virtual tmp<volScalarField> coeffs(const word& key) const;


### PR DESCRIPTION
This section of `divCapillaryStress()`

https://github.com/pzimbrod/thermocapillaryInterFoam/blob/20f3a8574dabb849e723d43e04b45c2d88351df3/phasesSystem/phaseSystem/phaseSystem.C#L1083-L1118

doesn't seem to really compute the correct divergence of the capillary stress tensor, the surface tension itself stays homogeneous. In a temperature gradient field, this can't be right.